### PR TITLE
Fix invalid parameter name in getMimeType function

### DIFF
--- a/src/main.swift
+++ b/src/main.swift
@@ -1242,7 +1242,7 @@ class NoteWindowController: NSWindowController, NSTableViewDataSource, NSTableVi
         return processedMarkdown
     }
     
-    private func getMimeType(for extension: String) -> String {
+    private func getMimeType(for fileExtension: String) -> String {
         let mimeTypes = [
             "png": "image/png",
             "jpg": "image/jpeg",
@@ -1252,7 +1252,7 @@ class NoteWindowController: NSWindowController, NSTableViewDataSource, NSTableVi
             "svg": "image/svg+xml",
             "bmp": "image/bmp"
         ]
-        return mimeTypes[`extension`.lowercased()] ?? "application/octet-stream"
+        return mimeTypes[fileExtension.lowercased()] ?? "application/octet-stream"
     }
 
     // 在 NoteWindowController 类中添加同步方法


### PR DESCRIPTION
## Summary
- fix compile error in `getMimeType` by renaming parameter

## Testing
- `swift build` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684fef0605e48330a8e5387d395b5b5e